### PR TITLE
Use ~ to install node-mapnik

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/chelm/mapnik-tiles",
   "dependencies": {
-    "mapnik": "^3.1.6",
+    "mapnik": "~3.1.6",
     "sphericalmercator": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This will protect your module from automatically upgrading to node-mapnik v3.7.0 (when it is published). This in turn will protect your users from breakages if they are running windows.

Refs https://github.com/mapnik/node-mapnik/issues/848